### PR TITLE
Feature: Add image resolution option on form

### DIFF
--- a/src/components/ArticleTitleAssistantForm.tsx
+++ b/src/components/ArticleTitleAssistantForm.tsx
@@ -11,6 +11,7 @@ import MenuItem from "@mui/material/MenuItem";
 
 import { generateSEO } from "@/services/openAi";
 import { SeoResponseData } from "@/types/openAiResponse";
+import { CreateImageRequestSizeEnum } from "openai";
 
 export interface ArticleTitleAssistantFormProps {
   setSeoResponseData: (data: SeoResponseData) => void;
@@ -20,19 +21,17 @@ export const ArticleTitleAssistantForm = ({
   setSeoResponseData,
 }: ArticleTitleAssistantFormProps) => {
   const [title, setTitle] = useState("");
-  const [imageResolution, setImageResolution] = useState("256x256");
-
-  console.log({ imageResolution });
+  const [imageResolution, setImageResolution] = useState<CreateImageRequestSizeEnum>("256x256");
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSeoResponseData({ loading: true, imageUrl: "", hashtags: [] });
-    const { imageUrl, hashtags } = await generateSEO(title);
+    const { imageUrl, hashtags } = await generateSEO(title, imageResolution);
     setSeoResponseData({ loading: false, imageUrl, hashtags });
   };
 
   const handleResolutionChange = (event: SelectChangeEvent) => {
-    setImageResolution(event.target.value as string);
+    setImageResolution(event.target.value as CreateImageRequestSizeEnum );
   };
 
   return (

--- a/src/components/ArticleTitleAssistantForm.tsx
+++ b/src/components/ArticleTitleAssistantForm.tsx
@@ -4,6 +4,10 @@ import { useState, FormEvent } from "react";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import InputLabel from "@mui/material/InputLabel";
+import Select, { SelectChangeEvent } from "@mui/material/Select";
+import MenuItem from "@mui/material/MenuItem";
 
 import { generateSEO } from "@/services/openAi";
 import { SeoResponseData } from "@/types/openAiResponse";
@@ -16,12 +20,19 @@ export const ArticleTitleAssistantForm = ({
   setSeoResponseData,
 }: ArticleTitleAssistantFormProps) => {
   const [title, setTitle] = useState("");
+  const [imageResolution, setImageResolution] = useState("256x256");
+
+  console.log({ imageResolution });
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSeoResponseData({ loading: true, imageUrl: "", hashtags: [] });
     const { imageUrl, hashtags } = await generateSEO(title);
     setSeoResponseData({ loading: false, imageUrl, hashtags });
+  };
+
+  const handleResolutionChange = (event: SelectChangeEvent) => {
+    setImageResolution(event.target.value as string);
   };
 
   return (
@@ -35,15 +46,34 @@ export const ArticleTitleAssistantForm = ({
       gap={1}
       mx={4}
     >
+      <Typography variant="subtitle1" gutterBottom>
+        Provide an article title and I will create an image and hashtags for
+        your article
+      </Typography>
+
+      <InputLabel id="article-title">Article Title</InputLabel>
       <TextField
         required
-        id="outlined-required"
+        id="article-title"
         label="Article Title"
         placeholder="How to be ranked in first page on Google"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         fullWidth
       />
+
+      <InputLabel id="image-resolution">Image Resolution</InputLabel>
+      <Select
+        labelId="image-resolution"
+        id="demo-simple-select"
+        value={imageResolution}
+        label="Age"
+        onChange={handleResolutionChange}
+      >
+        <MenuItem value={"256x256"}>256x256</MenuItem>
+        <MenuItem value={"512x512"}>512x512</MenuItem>
+        <MenuItem value={"1024x1024"}>1024x1024</MenuItem>
+      </Select>
       <Button type="submit" variant="contained">
         Create Data
       </Button>

--- a/src/services/openAi.ts
+++ b/src/services/openAi.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { Configuration, OpenAIApi } from "openai";
+import { Configuration, OpenAIApi, CreateImageRequestSizeEnum } from "openai";
 
 const configuration = new Configuration({
   apiKey: process.env.OPEN_AI_KEY,
@@ -8,11 +8,14 @@ const configuration = new Configuration({
 
 const openAi = new OpenAIApi(configuration);
 
-const generateImage = async (title: string) => {
+const generateImage = async (
+  title: string,
+  imageResolution: CreateImageRequestSizeEnum
+) => {
   const response: any = await openAi.createImage({
     prompt: title,
     n: 1,
-    size: "1024x1024",
+    size: imageResolution,
   });
 
   const imageUrl = response.data.data[0].url as string;
@@ -38,9 +41,12 @@ const generateHashtags = async (title: string) => {
   return hashtags;
 };
 
-export const generateSEO = async (title: string) => {
+export const generateSEO = async (
+  title: string,
+  imageResolution: CreateImageRequestSizeEnum
+) => {
   const [imageUrl, hashtags] = await Promise.all([
-    await generateImage(title),
+    await generateImage(title, imageResolution),
     await generateHashtags(title),
   ]);
   return {

--- a/src/types/openAiResponse.ts
+++ b/src/types/openAiResponse.ts
@@ -1,3 +1,5 @@
+import { CreateImageRequestSizeEnum } from "openai";
+
 export interface SeoResponseData {
   loading: boolean;
   imageUrl: string;


### PR DESCRIPTION
This PR adds a new field on ArticleTitleAssistantForm, the image resolution

# Possible values
- Docs
![Screen Shot 2023-07-28 at 09 21 03](https://github.com/PedroMarianoAlmeida/blog-assistant/assets/59484474/6465595d-2950-4d67-a003-703ab993c427)

- Type on node module
![Screen Shot 2023-07-28 at 09 22 47](https://github.com/PedroMarianoAlmeida/blog-assistant/assets/59484474/c8077561-9087-4a1c-9263-eeaa94a448f5)

- This type was added on UI and in the AI Service

# Ui Changes

- Before change
![Screen Shot 2023-07-28 at 09 25 27](https://github.com/PedroMarianoAlmeida/blog-assistant/assets/59484474/900ab340-4b68-4d1e-b797-a1d0ea238f1d)

- After change
![Screen Shot 2023-07-28 at 09 24 45](https://github.com/PedroMarianoAlmeida/blog-assistant/assets/59484474/9c42dd09-bf2c-4bf1-aae4-f9addcfad9fd)

- I made some other minor changes, like add a label to article input text
