### PR TITLE
Bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postinstall": "prisma generate",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/services/openAi.ts
+++ b/src/services/openAi.ts
@@ -48,7 +48,6 @@ export const generateSEO = async (
   title: string,
   imageResolution: CreateImageRequestSizeEnum
 ) => {
-  console.log("generateSEO");
   try {
     const { userId } = auth();
     if (!userId) throw new Error("Need to login");

--- a/src/services/openAi.ts
+++ b/src/services/openAi.ts
@@ -48,6 +48,7 @@ export const generateSEO = async (
   title: string,
   imageResolution: CreateImageRequestSizeEnum
 ) => {
+  console.log("generateSEO");
   try {
     const { userId } = auth();
     if (!userId) throw new Error("Need to login");


### PR DESCRIPTION
This PR solve the error or "infinite loading" that was happening only in production

It was a weird error because all loading is nested in a Try Catch block, so if some endpoint error happen should stop the loading and display the error.

But the error was in TypeScript and Prisma, the types on openAI.ts was not working properly because the types are not generated in production

So I need to add a script to generate the types in package.json

Solution is on Prisma docs: https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/vercel-caching-issue